### PR TITLE
Add stock moving average dashboard with Excel export

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -18,6 +18,36 @@
         </div>
 
         <div class="content">
+            <!-- Stock Moving Average Dashboard -->
+            <div class="stock-dashboard" id="stockDashboard">
+                <div class="stock-dashboard-header">
+                    <div class="stock-dashboard-copy">
+                        <h3>📈 Stock Moving Average Dashboard</h3>
+                        <p>Track short- and long-term trends across any basket of tickers in seconds.</p>
+                    </div>
+                    <button class="ma-secondary-btn" id="exportMovingAverages" disabled>
+                        Export to Excel
+                    </button>
+                </div>
+
+                <div class="ma-input-wrapper">
+                    <label for="symbolInput">Stock Symbols</label>
+                    <div class="ma-input-row">
+                        <input type="text" id="symbolInput" placeholder="Example: AAPL, MSFT, GOOG, TSLA">
+                        <button class="ma-primary-btn" id="fetchMovingAverages">Calculate Moving Averages</button>
+                    </div>
+                    <small class="ma-hint">Separate tickers with commas. We support up to 25 symbols per request.</small>
+                </div>
+
+                <div class="ma-status" id="stockDashboardStatus" role="status" aria-live="polite" style="display: none;"></div>
+
+                <div class="ma-grid" id="movingAverageGrid">
+                    <div class="ma-placeholder">
+                        Enter one or more comma-separated tickers and click <strong>Calculate Moving Averages</strong> to populate the dashboard.
+                    </div>
+                </div>
+            </div>
+
             <!-- File Upload Section -->
             <div class="upload-section">
                 <div class="upload-box" id="holdingsBox">
@@ -613,8 +643,10 @@
 
     <!-- External Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
-    
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+
     <!-- JavaScript Files -->
+<script src="js/stock-dashboard.js"></script>
 <script src="js/data-processor.js"></script>
 <script src="js/data-validator.js"></script>
 <script src="js/calculations.js"></script>

--- a/css/components.css
+++ b/css/components.css
@@ -319,6 +319,402 @@
     font-family: 'Courier New', monospace;
 }
 
+/* Stock Dashboard */
+.stock-dashboard {
+    margin-bottom: 40px;
+    padding: 32px;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.98) 0%, rgba(244, 246, 255, 0.98) 100%);
+    border-radius: 20px;
+    box-shadow: 0 20px 45px rgba(102, 126, 234, 0.2);
+    border: 1px solid rgba(118, 75, 162, 0.08);
+}
+
+.stock-dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.stock-dashboard-copy h3 {
+    margin-bottom: 8px;
+    font-size: 1.6em;
+    color: #2d2f48;
+}
+
+.stock-dashboard-copy p {
+    margin: 0;
+    color: #6c6f80;
+    max-width: 720px;
+    line-height: 1.5;
+}
+
+.ma-primary-btn,
+.ma-secondary-btn {
+    border: none;
+    border-radius: 14px;
+    font-weight: 600;
+    padding: 12px 22px;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    font-size: 0.95em;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+.ma-primary-btn {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(102, 126, 234, 0.25);
+}
+
+.ma-primary-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 28px rgba(102, 126, 234, 0.3);
+}
+
+.ma-secondary-btn {
+    background: rgba(102, 126, 234, 0.12);
+    color: #4b4f72;
+    box-shadow: none;
+}
+
+.ma-secondary-btn:hover {
+    background: rgba(102, 126, 234, 0.18);
+    transform: translateY(-1px);
+}
+
+.ma-primary-btn:disabled,
+.ma-secondary-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    transform: none;
+    box-shadow: none;
+}
+
+.ma-input-wrapper {
+    margin-top: 24px;
+}
+
+.ma-input-wrapper label {
+    display: block;
+    font-weight: 600;
+    color: #424466;
+    margin-bottom: 10px;
+}
+
+.ma-input-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.ma-input-row input {
+    flex: 1;
+    min-width: 260px;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(102, 126, 234, 0.25);
+    background: rgba(246, 247, 255, 0.9);
+    font-size: 1em;
+    transition: all 0.2s ease;
+    color: #2d2f48;
+}
+
+.ma-input-row input::placeholder {
+    color: #9a9db8;
+}
+
+.ma-input-row input:focus {
+    outline: none;
+    border-color: rgba(102, 126, 234, 0.8);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+    background: #ffffff;
+}
+
+.ma-hint {
+    display: block;
+    margin-top: 10px;
+    color: #7a7f9a;
+    font-size: 0.85em;
+}
+
+.ma-status {
+    margin-top: 24px;
+    padding: 14px 18px;
+    border-radius: 14px;
+    font-size: 0.95em;
+    display: none;
+    align-items: center;
+    gap: 10px;
+    border: 1px solid transparent;
+}
+
+.ma-status-icon {
+    font-size: 1.1em;
+}
+
+.ma-status--loading {
+    background: rgba(255, 199, 0, 0.12);
+    border-color: rgba(255, 199, 0, 0.3);
+    color: #876400;
+}
+
+.ma-status--success {
+    background: rgba(46, 204, 113, 0.12);
+    border-color: rgba(46, 204, 113, 0.3);
+    color: #1e7d3c;
+}
+
+.ma-status--error {
+    background: rgba(231, 76, 60, 0.12);
+    border-color: rgba(231, 76, 60, 0.3);
+    color: #a33125;
+}
+
+.ma-status--info {
+    background: rgba(102, 126, 234, 0.12);
+    border-color: rgba(102, 126, 234, 0.3);
+    color: #4b51a3;
+}
+
+.ma-grid {
+    margin-top: 28px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.ma-placeholder {
+    padding: 24px;
+    border-radius: 16px;
+    background: rgba(246, 247, 255, 0.8);
+    color: #6c6f80;
+    text-align: center;
+    font-size: 0.95em;
+    border: 1px dashed rgba(118, 75, 162, 0.2);
+}
+
+.ma-card {
+    padding: 24px;
+    border-radius: 18px;
+    background: linear-gradient(155deg, #ffffff 0%, #f7f9ff 100%);
+    border: 1px solid rgba(102, 126, 234, 0.08);
+    box-shadow: 0 18px 36px rgba(102, 126, 234, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.ma-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 24px 44px rgba(102, 126, 234, 0.2);
+}
+
+.ma-card-heading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.ma-symbol {
+    font-size: 1.2em;
+    font-weight: 700;
+    color: #2d2f48;
+    letter-spacing: 0.02em;
+}
+
+.ma-trend {
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-weight: 700;
+}
+
+.ma-trend--positive {
+    background: rgba(46, 204, 113, 0.15);
+    color: #1e7d3c;
+}
+
+.ma-trend--negative {
+    background: rgba(231, 76, 60, 0.16);
+    color: #b63a2f;
+}
+
+.ma-trend--neutral {
+    background: rgba(52, 152, 219, 0.16);
+    color: #236b9a;
+}
+
+.ma-price {
+    font-size: 1.4em;
+    font-weight: 700;
+    color: #1f2240;
+}
+
+.ma-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ma-metric {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.ma-label {
+    color: #6c6f80;
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
+.ma-values {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+}
+
+.ma-value {
+    font-weight: 700;
+    color: #2d2f48;
+}
+
+.ma-delta {
+    font-size: 0.8em;
+    font-weight: 700;
+    padding: 2px 10px;
+    border-radius: 999px;
+}
+
+.ma-delta.positive {
+    background: rgba(46, 204, 113, 0.18);
+    color: #1e7d3c;
+}
+
+.ma-delta.negative {
+    background: rgba(231, 76, 60, 0.18);
+    color: #b63a2f;
+}
+
+.ma-card-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    color: #7a7f9a;
+    font-size: 0.85em;
+    border-top: 1px solid rgba(102, 126, 234, 0.12);
+    padding-top: 12px;
+}
+
+.ma-footer-divider {
+    color: rgba(102, 126, 234, 0.5);
+}
+
+.ma-card--error {
+    background: linear-gradient(150deg, rgba(255, 245, 246, 0.98) 0%, rgba(255, 235, 238, 0.95) 100%);
+    border: 1px solid rgba(231, 76, 60, 0.25);
+    box-shadow: 0 18px 36px rgba(231, 76, 60, 0.18);
+}
+
+.ma-error-badge {
+    background: rgba(231, 76, 60, 0.2);
+    color: #b63a2f;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.ma-error-message {
+    margin: 0;
+    color: #9b3d35;
+    line-height: 1.5;
+    font-size: 0.95em;
+}
+
+.ma-card--loading {
+    position: relative;
+    overflow: hidden;
+}
+
+.ma-skeleton {
+    height: 14px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #f1f3ff 0%, #e0e4ff 50%, #f1f3ff 100%);
+    background-size: 200% 100%;
+    animation: ma-shimmer 1.6s ease-in-out infinite;
+    margin-bottom: 12px;
+}
+
+.ma-skeleton--title {
+    width: 55%;
+    height: 18px;
+    margin-bottom: 16px;
+}
+
+.ma-skeleton--price {
+    width: 40%;
+    height: 22px;
+    margin-bottom: 20px;
+}
+
+.ma-skeleton--line.short {
+    width: 65%;
+}
+
+@keyframes ma-shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+@media (max-width: 768px) {
+    .stock-dashboard {
+        padding: 24px;
+    }
+
+    .ma-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .stock-dashboard-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .ma-primary-btn,
+    .ma-secondary-btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .ma-input-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .ma-input-row input {
+        width: 100%;
+    }
+}
+
 .coverage-stats {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));

--- a/js/stock-dashboard.js
+++ b/js/stock-dashboard.js
@@ -1,0 +1,482 @@
+// Stock Moving Average Dashboard Logic
+
+const StockDashboardState = {
+    data: [],
+    loading: false
+};
+
+const SYMBOL_PATTERN = /^[A-Za-z0-9.\-^=]{1,15}$/;
+const MAX_SYMBOLS = 25;
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const fetchButton = document.getElementById('fetchMovingAverages');
+    const exportButton = document.getElementById('exportMovingAverages');
+    const input = document.getElementById('symbolInput');
+
+    if (fetchButton) {
+        fetchButton.addEventListener('click', handleFetchMovingAverages);
+    }
+
+    if (exportButton) {
+        exportButton.addEventListener('click', exportMovingAveragesToExcel);
+    }
+
+    if (input) {
+        input.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleFetchMovingAverages();
+            }
+        });
+    }
+});
+
+function handleFetchMovingAverages() {
+    const input = document.getElementById('symbolInput');
+    if (!input) {
+        return;
+    }
+
+    const rawSymbols = input.value
+        .split(',')
+        .map(symbol => symbol.trim().toUpperCase())
+        .filter(Boolean);
+
+    const uniqueSymbols = Array.from(new Set(rawSymbols));
+
+    if (uniqueSymbols.length === 0) {
+        setDashboardStatus('error', 'Enter one or more ticker symbols separated by commas.');
+        renderPlaceholderState();
+        return;
+    }
+
+    const validSymbols = uniqueSymbols.filter(symbol => SYMBOL_PATTERN.test(symbol));
+    const invalidSymbols = uniqueSymbols.filter(symbol => !SYMBOL_PATTERN.test(symbol));
+
+    if (validSymbols.length === 0) {
+        setDashboardStatus('error', 'Enter one or more valid ticker symbols (letters, numbers, ".", "-", "^").');
+        renderPlaceholderState();
+        return;
+    }
+
+    const truncatedSymbols = validSymbols.length > MAX_SYMBOLS ? validSymbols.slice(MAX_SYMBOLS) : [];
+    const symbolsToQuery = validSymbols.slice(0, MAX_SYMBOLS);
+
+    const noteParts = [];
+    if (invalidSymbols.length) {
+        noteParts.push(`ignoring ${invalidSymbols.join(', ')}`);
+    }
+    if (truncatedSymbols.length) {
+        noteParts.push(`processing only the first ${symbolsToQuery.length} tickers`);
+    }
+
+    const suffix = noteParts.length ? ` (${noteParts.join('; ')})` : '';
+
+    setLoadingState(true);
+    setDashboardStatus('loading', `Fetching data for ${symbolsToQuery.join(', ')}${suffix}.`);
+    renderLoadingState(symbolsToQuery.length);
+
+    fetch(`/api/moving-averages?symbols=${encodeURIComponent(symbolsToQuery.join(','))}`)
+        .then(response => response.json())
+        .then(payload => handleMovingAverageResponse(payload))
+        .catch(error => {
+            console.error('Error fetching moving averages:', error);
+            setDashboardStatus('error', 'We ran into an issue fetching data. Please try again shortly.');
+            renderErrorState('Unable to retrieve moving averages right now.');
+            StockDashboardState.data = [];
+            updateExportButtonState();
+        })
+        .finally(() => {
+            setLoadingState(false);
+        });
+}
+
+function handleMovingAverageResponse(payload) {
+    if (!payload || payload.success === false) {
+        const message = payload && payload.error ? payload.error : 'Unable to retrieve moving averages.';
+        setDashboardStatus('error', message);
+        renderErrorState('No data returned from the moving average service.');
+        StockDashboardState.data = [];
+        updateExportButtonState();
+        return;
+    }
+
+    const results = Array.isArray(payload.data) ? payload.data : [];
+    const validResults = results.filter(item => item && !item.error && item.movingAverages);
+    const errorResults = results.filter(item => item && item.error);
+
+    StockDashboardState.data = validResults;
+
+    renderMovingAverageGrid(results);
+    updateExportButtonState();
+
+    const meta = payload.meta || {};
+    const invalidSymbols = Array.isArray(meta.invalidSymbols) ? meta.invalidSymbols : [];
+    const truncatedSymbols = Array.isArray(meta.truncatedSymbols) ? meta.truncatedSymbols : [];
+
+    const messageSegments = [];
+    if (validResults.length) {
+        messageSegments.push(`Loaded moving averages for ${validResults.length} symbol${validResults.length === 1 ? '' : 's'}.`);
+    }
+    if (errorResults.length) {
+        const missingSymbols = errorResults
+            .map(item => item.symbol)
+            .filter(Boolean);
+        if (missingSymbols.length) {
+            messageSegments.push(`No recent pricing data for ${missingSymbols.join(', ')}.`);
+        } else {
+            messageSegments.push(`Unable to calculate data for ${errorResults.length} symbol${errorResults.length === 1 ? '' : 's'}.`);
+        }
+    }
+    if (invalidSymbols.length) {
+        messageSegments.push(`Ignored invalid ticker${invalidSymbols.length === 1 ? '' : 's'}: ${invalidSymbols.join(', ')}.`);
+    }
+    if (truncatedSymbols.length) {
+        messageSegments.push(`Skipped additional symbol${truncatedSymbols.length === 1 ? '' : 's'} due to the 25 ticker limit: ${truncatedSymbols.join(', ')}.`);
+    }
+
+    const statusType = validResults.length && !errorResults.length ? 'success' : validResults.length ? 'info' : 'error';
+    const fallbackMessage = validResults.length ? 'Moving averages loaded.' : 'No moving average data returned.';
+
+    setDashboardStatus(statusType, messageSegments.join(' ') || fallbackMessage);
+
+    if (!results.length) {
+        renderErrorState('No price history was returned for the requested symbols.');
+    }
+}
+
+function renderMovingAverageGrid(items) {
+    const grid = document.getElementById('movingAverageGrid');
+    if (!grid) {
+        return;
+    }
+
+    grid.innerHTML = '';
+
+    if (!items.length) {
+        renderPlaceholderState();
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    items.forEach(item => {
+        if (!item) {
+            return;
+        }
+
+        if (item.error) {
+            fragment.appendChild(createErrorCard(item.symbol, item.error));
+        } else {
+            fragment.appendChild(createDataCard(item));
+        }
+    });
+
+    grid.appendChild(fragment);
+}
+
+function createDataCard(item) {
+    const card = document.createElement('div');
+    card.className = 'ma-card';
+
+    const price = Number(item.lastPrice);
+    const movingAverages = item.movingAverages || {};
+    const trend = determineTrend(movingAverages, price);
+
+    const footerSegments = [];
+    if (Number.isFinite(Number(item.historyLength))) {
+        const history = Number(item.historyLength);
+        footerSegments.push(`${history} data point${history === 1 ? '' : 's'}`);
+    }
+    if (item.lastUpdated) {
+        footerSegments.push(formatDateTime(item.lastUpdated));
+    }
+
+    card.innerHTML = `
+        <div class="ma-card-header">
+            <div class="ma-card-heading">
+                <span class="ma-symbol">${item.symbol || '—'}</span>
+                <span class="ma-trend ma-trend--${trend.className}">${trend.label}</span>
+            </div>
+            <span class="ma-price">${formatCurrency(price)}</span>
+        </div>
+        <div class="ma-card-body">
+            ${createMetricRow('9-Day MA', movingAverages.ma9, price)}
+            ${createMetricRow('21-Day MA', movingAverages.ma21, price)}
+            ${createMetricRow('50-Day MA', movingAverages.ma50, price)}
+            ${createMetricRow('200-Day MA', movingAverages.ma200, price)}
+        </div>
+        <div class="ma-card-footer">
+            ${footerSegments.length ? footerSegments.map(text => `<span>${text}</span>`).join('<span class="ma-footer-divider">•</span>') : '<span>Latest data unavailable</span>'}
+        </div>
+    `;
+
+    return card;
+}
+
+function createErrorCard(symbol, message) {
+    const card = document.createElement('div');
+    card.className = 'ma-card ma-card--error';
+
+    const safeMessage = message || 'No pricing data is currently available for this ticker.';
+
+    card.innerHTML = `
+        <div class="ma-card-header">
+            <span class="ma-symbol">${symbol || 'Unknown'}</span>
+            <span class="ma-error-badge">Data Unavailable</span>
+        </div>
+        <p class="ma-error-message">${safeMessage}</p>
+    `;
+
+    return card;
+}
+
+function renderLoadingState(symbolCount) {
+    const grid = document.getElementById('movingAverageGrid');
+    if (!grid) {
+        return;
+    }
+
+    grid.innerHTML = '';
+
+    const cardsToRender = Math.min(Math.max(symbolCount, 1), 6);
+
+    for (let i = 0; i < cardsToRender; i += 1) {
+        const card = document.createElement('div');
+        card.className = 'ma-card ma-card--loading';
+        card.innerHTML = `
+            <div class="ma-skeleton ma-skeleton--title"></div>
+            <div class="ma-skeleton ma-skeleton--price"></div>
+            <div class="ma-skeleton ma-skeleton--line"></div>
+            <div class="ma-skeleton ma-skeleton--line short"></div>
+            <div class="ma-skeleton ma-skeleton--line"></div>
+            <div class="ma-skeleton ma-skeleton--line short"></div>
+        `;
+        grid.appendChild(card);
+    }
+}
+
+function renderPlaceholderState() {
+    renderErrorState('Enter one or more comma-separated tickers and click “Calculate Moving Averages” to populate the dashboard.');
+}
+
+function renderErrorState(message) {
+    const grid = document.getElementById('movingAverageGrid');
+    if (!grid) {
+        return;
+    }
+
+    grid.innerHTML = '';
+    const placeholder = document.createElement('div');
+    placeholder.className = 'ma-placeholder';
+    placeholder.textContent = message;
+    grid.appendChild(placeholder);
+}
+
+function setLoadingState(isLoading) {
+    const fetchButton = document.getElementById('fetchMovingAverages');
+    const exportButton = document.getElementById('exportMovingAverages');
+
+    StockDashboardState.loading = isLoading;
+
+    if (fetchButton) {
+        fetchButton.disabled = isLoading;
+        fetchButton.textContent = isLoading ? 'Loading…' : 'Calculate Moving Averages';
+    }
+
+    if (exportButton && isLoading) {
+        exportButton.disabled = true;
+    }
+}
+
+function updateExportButtonState() {
+    const exportButton = document.getElementById('exportMovingAverages');
+    if (!exportButton) {
+        return;
+    }
+
+    exportButton.disabled = !Array.isArray(StockDashboardState.data) || StockDashboardState.data.length === 0;
+}
+
+function setDashboardStatus(type, message) {
+    const statusEl = document.getElementById('stockDashboardStatus');
+    if (!statusEl) {
+        return;
+    }
+
+    if (!message) {
+        statusEl.style.display = 'none';
+        statusEl.className = 'ma-status';
+        statusEl.textContent = '';
+        return;
+    }
+
+    const icons = {
+        loading: '⏳',
+        success: '✅',
+        error: '⚠️',
+        info: 'ℹ️'
+    };
+
+    statusEl.style.display = 'flex';
+    statusEl.className = `ma-status ma-status--${['loading', 'success', 'error', 'info'].includes(type) ? type : 'info'}`;
+
+    statusEl.innerHTML = '';
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'ma-status-icon';
+    iconSpan.textContent = icons[type] || icons.info;
+
+    const textSpan = document.createElement('span');
+    textSpan.textContent = message;
+
+    statusEl.appendChild(iconSpan);
+    statusEl.appendChild(textSpan);
+}
+
+function createMetricRow(label, value, price) {
+    const formattedValue = formatCurrency(value);
+    const deltaMarkup = buildDeltaMarkup(value, price);
+
+    return `
+        <div class="ma-metric">
+            <span class="ma-label">${label}</span>
+            <div class="ma-values">
+                <span class="ma-value">${formattedValue}</span>
+                ${deltaMarkup}
+            </div>
+        </div>
+    `;
+}
+
+function buildDeltaMarkup(value, price) {
+    const numericValue = Number(value);
+    const numericPrice = Number(price);
+
+    if (!Number.isFinite(numericValue) || !Number.isFinite(numericPrice) || numericValue === 0) {
+        return '';
+    }
+
+    const diff = ((numericPrice - numericValue) / numericValue) * 100;
+
+    if (!Number.isFinite(diff)) {
+        return '';
+    }
+
+    const className = diff >= 0 ? 'positive' : 'negative';
+    const formatted = `${diff >= 0 ? '+' : ''}${Math.abs(diff) < 0.01 ? diff.toFixed(4) : diff.toFixed(2)}%`;
+
+    return `<span class="ma-delta ${className}">${formatted}</span>`;
+}
+
+function determineTrend(movingAverages, price) {
+    const numericPrice = Number(price);
+    const ma50 = Number(movingAverages && movingAverages.ma50);
+    const ma200 = Number(movingAverages && movingAverages.ma200);
+
+    const hasPrice = Number.isFinite(numericPrice);
+    const has50 = Number.isFinite(ma50);
+    const has200 = Number.isFinite(ma200);
+
+    if (hasPrice && has50 && has200) {
+        if (numericPrice >= ma50 && ma50 >= ma200) {
+            return { label: 'Strong Uptrend', className: 'positive' };
+        }
+        if (numericPrice >= ma50 && ma50 < ma200) {
+            return { label: 'Short-Term Strength', className: 'positive' };
+        }
+        if (numericPrice < ma50 && ma50 < ma200) {
+            return { label: 'Downtrend Risk', className: 'negative' };
+        }
+        return { label: 'Mixed Signals', className: 'neutral' };
+    }
+
+    if (hasPrice && has50) {
+        return numericPrice >= ma50
+            ? { label: 'Above 50 DMA', className: 'positive' }
+            : { label: 'Below 50 DMA', className: 'negative' };
+    }
+
+    return { label: 'Signal Pending', className: 'neutral' };
+}
+
+function formatCurrency(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return 'N/A';
+    }
+    return currencyFormatter.format(numeric);
+}
+
+function formatDateTime(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return 'Updated time unavailable';
+    }
+    return date.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+    });
+}
+
+function exportMovingAveragesToExcel() {
+    if (!Array.isArray(StockDashboardState.data) || StockDashboardState.data.length === 0) {
+        setDashboardStatus('error', 'Load moving averages before exporting to Excel.');
+        return;
+    }
+
+    if (typeof XLSX === 'undefined') {
+        setDashboardStatus('error', 'Excel export library is not available. Check your connection and try again.');
+        return;
+    }
+
+    const headers = ['Symbol', 'Last Price', '9 Day MA', '21 Day MA', '50 Day MA', '200 Day MA', 'Last Updated', 'Data Points'];
+    const rows = StockDashboardState.data.map(item => [
+        item.symbol || '',
+        toNumberOrBlank(item.lastPrice),
+        toNumberOrBlank(item.movingAverages && item.movingAverages.ma9),
+        toNumberOrBlank(item.movingAverages && item.movingAverages.ma21),
+        toNumberOrBlank(item.movingAverages && item.movingAverages.ma50),
+        toNumberOrBlank(item.movingAverages && item.movingAverages.ma200),
+        formatDateForExport(item.lastUpdated),
+        Number.isFinite(Number(item.historyLength)) ? Number(item.historyLength) : ''
+    ]);
+
+    const worksheetData = [headers, ...rows];
+    const worksheet = XLSX.utils.aoa_to_sheet(worksheetData);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Moving Averages');
+
+    const isoDate = new Date().toISOString().split('T')[0];
+    const filename = `moving-averages-${isoDate}.xlsx`;
+    XLSX.writeFile(workbook, filename);
+
+    setDashboardStatus('success', `Excel export generated (${filename}).`);
+}
+
+function toNumberOrBlank(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : '';
+}
+
+function formatDateForExport(value) {
+    if (!value) {
+        return '';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+}

--- a/server.js
+++ b/server.js
@@ -1,11 +1,14 @@
 // Simple Node.js server to handle file auto-loading
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
 
 const PORT = 8080;
 const DOWNLOADS_DIR = 'C:\\Users\\Chad\\Downloads';
+const MOVING_AVERAGE_SYMBOL_REGEX = /^[A-Za-z0-9.\-^=]{1,15}$/;
+const MAX_MOVING_AVERAGE_SYMBOLS = 25;
 
 // CORS headers to allow browser access
 const corsHeaders = {
@@ -19,7 +22,7 @@ const corsHeaders = {
 function findMostRecentFile(directory, pattern) {
     try {
         const files = fs.readdirSync(directory);
-        const matchingFiles = files.filter(file => 
+        const matchingFiles = files.filter(file =>
             file.startsWith(pattern) && file.toLowerCase().endsWith('.csv')
         );
         
@@ -46,6 +49,110 @@ function findMostRecentFile(directory, pattern) {
         console.error('Error finding files:', error);
         return null;
     }
+}
+
+function calculateSMA(history, windowSize) {
+    if (!Array.isArray(history) || history.length < windowSize) {
+        return null;
+    }
+
+    const recentHistory = history.slice(-windowSize);
+    const total = recentHistory.reduce((acc, entry) => acc + Number(entry.close || 0), 0);
+
+    if (!Number.isFinite(total)) {
+        return null;
+    }
+
+    return Number((total / windowSize).toFixed(2));
+}
+
+function fetchSymbolMovingAverages(symbol) {
+    return new Promise((resolve) => {
+        const requestUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?range=1y&interval=1d&includePrePost=false&events=div%2Csplit`;
+
+        const request = https.get(requestUrl, (apiRes) => {
+            let rawData = '';
+
+            apiRes.on('data', (chunk) => {
+                rawData += chunk;
+            });
+
+            apiRes.on('end', () => {
+                if (apiRes.statusCode !== 200) {
+                    resolve({
+                        symbol,
+                        error: `Received status ${apiRes.statusCode} from data provider.`
+                    });
+                    return;
+                }
+
+                try {
+                    const parsed = JSON.parse(rawData);
+                    const chart = parsed && parsed.chart && Array.isArray(parsed.chart.result)
+                        ? parsed.chart.result[0]
+                        : null;
+
+                    if (!chart || !Array.isArray(chart.timestamp)) {
+                        resolve({ symbol, error: 'No price history returned.' });
+                        return;
+                    }
+
+                    const closeValues = chart.indicators
+                        && Array.isArray(chart.indicators.quote)
+                        && chart.indicators.quote[0]
+                        ? chart.indicators.quote[0].close || []
+                        : [];
+
+                    const timestamps = chart.timestamp;
+                    const history = [];
+
+                    for (let i = 0; i < timestamps.length; i += 1) {
+                        const close = closeValues[i];
+                        if (close !== null && close !== undefined) {
+                            history.push({
+                                timestamp: timestamps[i],
+                                close: Number(close)
+                            });
+                        }
+                    }
+
+                    if (!history.length) {
+                        resolve({ symbol, error: 'Price history missing closing values.' });
+                        return;
+                    }
+
+                    const movingAverages = {
+                        ma9: calculateSMA(history, 9),
+                        ma21: calculateSMA(history, 21),
+                        ma50: calculateSMA(history, 50),
+                        ma200: calculateSMA(history, 200)
+                    };
+
+                    const lastEntry = history[history.length - 1];
+
+                    resolve({
+                        symbol,
+                        lastPrice: Number(Number(lastEntry.close).toFixed(2)),
+                        lastUpdated: new Date(lastEntry.timestamp * 1000).toISOString(),
+                        historyLength: history.length,
+                        movingAverages
+                    });
+                } catch (err) {
+                    console.error(`Error parsing data for ${symbol}:`, err.message);
+                    resolve({ symbol, error: 'Unable to parse data response.' });
+                }
+            });
+        });
+
+        request.on('error', (err) => {
+            console.error(`Error fetching data for ${symbol}:`, err.message);
+            resolve({ symbol, error: 'Unable to reach data provider.' });
+        });
+
+        request.setTimeout(8000, () => {
+            request.destroy(new Error('Request timed out'));
+        });
+    });
 }
 
 // Create HTTP server
@@ -130,7 +237,7 @@ const server = http.createServer((req, res) => {
     // API endpoint to get the most recent Market Chameleon file
     if (pathname === '/api/latest-chameleon') {
         const file = findMostRecentFile(DOWNLOADS_DIR, 'StockWatchlist_ULTY');
-        
+
         if (file) {
             const content = fs.readFileSync(file.path, 'utf8');
             res.writeHead(200, corsHeaders);
@@ -149,7 +256,74 @@ const server = http.createServer((req, res) => {
         }
         return;
     }
-    
+
+    if (pathname === '/api/moving-averages') {
+        const { symbols } = parsedUrl.query || {};
+
+        if (!symbols) {
+            res.writeHead(400, corsHeaders);
+            res.end(JSON.stringify({
+                success: false,
+                error: 'Please provide a comma-separated list of ticker symbols.'
+            }));
+            return;
+        }
+
+        const rawSymbols = symbols
+            .split(',')
+            .map(symbol => symbol.trim().toUpperCase())
+            .filter(Boolean);
+
+        const uniqueSymbols = Array.from(new Set(rawSymbols));
+        const validSymbols = uniqueSymbols.filter(symbol => MOVING_AVERAGE_SYMBOL_REGEX.test(symbol));
+        const invalidSymbols = uniqueSymbols.filter(symbol => !MOVING_AVERAGE_SYMBOL_REGEX.test(symbol));
+
+        if (validSymbols.length === 0) {
+            res.writeHead(400, corsHeaders);
+            res.end(JSON.stringify({
+                success: false,
+                error: 'No valid ticker symbols were provided.'
+            }));
+            return;
+        }
+
+        const truncatedSymbols = validSymbols.length > MAX_MOVING_AVERAGE_SYMBOLS
+            ? validSymbols.slice(MAX_MOVING_AVERAGE_SYMBOLS)
+            : [];
+
+        const symbolsToProcess = validSymbols.slice(0, MAX_MOVING_AVERAGE_SYMBOLS);
+
+        Promise.all(symbolsToProcess.map(symbol => fetchSymbolMovingAverages(symbol)))
+            .then(results => {
+                res.writeHead(200, corsHeaders);
+                res.end(JSON.stringify({
+                    success: true,
+                    data: results,
+                    meta: {
+                        requested: uniqueSymbols,
+                        accepted: symbolsToProcess,
+                        invalidSymbols,
+                        truncatedSymbols,
+                        counts: {
+                            requested: uniqueSymbols.length,
+                            accepted: symbolsToProcess.length,
+                            invalid: invalidSymbols.length,
+                            truncated: truncatedSymbols.length
+                        }
+                    }
+                }));
+            })
+            .catch(error => {
+                console.error('Error retrieving moving averages:', error);
+                res.writeHead(500, corsHeaders);
+                res.end(JSON.stringify({
+                    success: false,
+                    error: 'Failed to retrieve moving average data.'
+                }));
+            });
+        return;
+    }
+
     // Default 404
     res.writeHead(404);
     res.end('Not found');
@@ -162,4 +336,5 @@ server.listen(PORT, () => {
     console.log(`\nAPI Endpoints:`);
     console.log(`  GET http://localhost:${PORT}/api/latest-holdings - Get latest TidalETF file`);
     console.log(`  GET http://localhost:${PORT}/api/latest-chameleon - Get latest Market Chameleon file`);
+    console.log(`  GET http://localhost:${PORT}/api/moving-averages?symbols=AAPL,MSFT - Get moving averages for tickers`);
 });


### PR DESCRIPTION
## Summary
- add a stock moving average dashboard entry form to the landing page
- style the new dashboard and cards and implement client logic for fetching, rendering, and exporting data to Excel
- add a server endpoint that proxies Yahoo Finance data and returns 9/21/50/200 day moving averages per ticker

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68ca1bb6d21483279e00f73cfb7b0630